### PR TITLE
Fix the `print` command

### DIFF
--- a/compiler/src/macros/commands/Print.ts
+++ b/compiler/src/macros/commands/Print.ts
@@ -1,11 +1,17 @@
 import { InstructionBase } from "../../instructions";
 import { MacroFunction } from "..";
-import { IScope, IValue } from "../../types";
+import { IInstruction, IScope, IValue } from "../../types";
 
 export class Print extends MacroFunction {
   constructor(scope: IScope) {
     super(scope, (...values: IValue[]) => {
-      return [null, [new InstructionBase("print", ...values)]];
+      const inst: IInstruction[] = [];
+
+      for (const value of values) {
+        inst.push(new InstructionBase("print", value));
+      }
+
+      return [null, inst];
     });
   }
 }


### PR DESCRIPTION
Fixes the mlog output of the `print` command when it receives more than one argument.

Example:
```js
print("a", "b", "c", "d")
```
had the following output:

```js
print "a" "b" "c" "d"
```
And those strings would not be concatenated during runtime.

So now each value has its own `print` instruction