### PR TITLE
Make the build out path optional

### DIFF
--- a/compiler/src/bin.ts
+++ b/compiler/src/bin.ts
@@ -5,7 +5,7 @@ import { compile } from ".";
 import { highlight } from "cli-highlight";
 import yargs from "yargs";
 import chalk from "chalk";
-import { resolve } from "path";
+import { join, parse, resolve } from "path";
 
 yargs(hideBin(process.argv))
   .command(
@@ -25,10 +25,10 @@ yargs(hideBin(process.argv))
     argv => {
       const path = argv.path;
       if (!path) return console.log("missing required path argument");
-      if (!out) return console.log("missing output path");
       if (!existsSync(path))
         return console.log(`file at ${path} does not exist`);
-      const code = readFileSync(path as string, "utf8");
+      const out = argv.out ?? defaultOutPath(path);
+      const code = readFileSync(path, "utf8");
       const [output, error, [node]] = compile(code);
       if (error) {
         // @ts-ignore
@@ -71,3 +71,8 @@ yargs(hideBin(process.argv))
   .scriptName("mlogjs")
   .demandCommand()
   .parse();
+
+function defaultOutPath(path: string) {
+  const parsed = parse(path);
+  return join(parsed.dir, `${parsed.name}.mlog`);
+}

--- a/compiler/src/bin.ts
+++ b/compiler/src/bin.ts
@@ -15,14 +15,15 @@ yargs(hideBin(process.argv))
       return yargs
         .positional("path", {
           describe: "path of the file to compile",
+          type: "string",
         })
         .positional("out", {
           describe: "path of the output file",
+          type: "string",
         });
     },
     argv => {
-      const path = argv.path as string;
-      const out = argv.out as string;
+      const path = argv.path;
       if (!path) return console.log("missing required path argument");
       if (!out) return console.log("missing output path");
       if (!existsSync(path))

--- a/compiler/src/bin.ts
+++ b/compiler/src/bin.ts
@@ -28,6 +28,8 @@ yargs(hideBin(process.argv))
       if (!existsSync(path))
         return console.log(`file at ${path} does not exist`);
       const out = argv.out ?? defaultOutPath(path);
+      if (path == out)
+        return console.log("The out path cannot be the same as the input path");
       const code = readFileSync(path, "utf8");
       const [output, error, [node]] = compile(code);
       if (error) {


### PR DESCRIPTION
This pull request makes it possible for the user to only specify the input path and have the compiler automatically infer the output path.

The default output path will be the input path but with the `.mlog` file extension.